### PR TITLE
Update Coalition Uniforms

### DIFF
--- a/Xml/Items/Jobgear/Coalition.xml
+++ b/Xml/Items/Jobgear/Coalition.xml
@@ -1,99 +1,106 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Items>
-  <!-- Helmets Start -->
-  <Item name="" identifier="WR_coalitionhelmet" category="Equipment" tags="smallitem,clothing" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_metal_heavy" scale="0.325">
-    <Sprite name="Coalition Helmet" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" sourcerect="607,0,89,67" depth="0.6" origin="0.5,0.5" />
-    <Body radius="30" density="25" />
-    <Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
-      <damagemodifier afflictionidentifiers="gunshotwound" armorsector="0.0,360.0" damagemultiplier="0.8" damagesound="LimbArmor" deflectprojectiles="true" />
-      <damagemodifier afflictionidentifiers="lacerations, blunttrauma, explosiondamage, bleeding" armorsector="0.0,360.0" damagemultiplier="0.6" damagesound="LimbArmor" deflectprojectiles="true" />
-      <damagemodifier afflictionidentifiers="concussion" armorsector="0.0,360.0" damagemultiplier="0.1" damagesound="" deflectprojectiles="true" />
-      <SkillModifier skillidentifier="weapons" skillvalue="10" />
-      <sprite name="Coalition Helmet Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.65" hidewearablesoftype="Hair" sourcerect="607,0,89,102" origin="0.535,0.65" />
-    </Wearable>
-  </Item>
-  <Item name="" identifier="WR_coalitionmedhelmet" category="Equipment" tags="smallitem,clothing" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_metal_heavy" scale="0.325">
-    <Sprite name="Coalition Medic Helmet" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" sourcerect="607,102,89,43" depth="0.6" origin="0.5,0.5" />
-    <Body radius="30" density="25" />
-    <Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
-      <damagemodifier afflictionidentifiers="gunshotwound, bitewounds" armorsector="0.0,360.0" damagemultiplier="0.8" damagesound="LimbArmor" deflectprojectiles="true" />
-      <damagemodifier afflictionidentifiers="lacerations, blunttrauma, explosiondamage, bleeding" armorsector="0.0,360.0" damagemultiplier="0.6" damagesound="LimbArmor" deflectprojectiles="true" />
-      <damagemodifier afflictionidentifiers="concussion" armorsector="0.0,360.0" damagemultiplier="0.1" damagesound="" deflectprojectiles="true" />
-      <SkillModifier skillidentifier="medical" skillvalue="10" />
-      <sprite name="Coalition Medic Helmet Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.65" hidewearablesoftype="Hair" sourcerect="607,102,89,79" origin="0.535,0.54" />
-    </Wearable>
-  </Item>
-  <Item name="" identifier="WR_coalitioncomhat" category="Equipment" tags="smallitem,clothing,command" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_soft" scale="0.25">
-    <Sprite name="Coalition Commander Hat" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" sourcerect="385,58,120,47" depth="0.6" origin="0.5,0.14" />
-    <Body radius="30" density="25" />
-    <Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
-      <damagemodifier afflictionidentifiers="lacerations, blunttrauma, explosiondamage, bleeding" armorsector="0.0,360.0" damagemultiplier="0.8" damagesound="LimbArmor" deflectprojectiles="true" />
-      <SkillModifier skillidentifier="weapons" skillvalue="10" />
-      <sprite name="Coalition Commander Hat Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.5" sourcerect="385,58,120,47" origin="0.525,1.2" />
-    </Wearable>
-  </Item>
-  <!-- Helmets End -->
-  <!-- Infantry gear Start -->
-  <Item name="" identifier="WR_coalitiongear" category="Equipment" tags="mediumitem,clothing" scale="0.5" cargocontaineridentifier="metalcrate" allowasextracargo="true" description="" impactsoundtag="impact_soft">
-    <InventoryIcon texture="%ModDir%/Sprites/Items/Inventory Icons.png" sourcerect="256,0,64,64" origin="0.5,0.5" />
-    <Sprite texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" sourcerect="443,162,69,94" depth="0.6" origin="0.5,0.35" />
-    <Body radius="30" height="30" density="15" />
-    <Wearable slots="OuterClothes" msg="ItemMsgPickUpSelect" canbeselected="false" canbepicked="true" pickkey="Select">
-      <sprite name="Coalition Chest Rig Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" limb="Torso" hidelimb="false" sourcerect="443,162,69,94" inherittexturescale="true" origin="0.45,0.65" />
-      <SkillModifier skillidentifier="weapons" skillvalue="30" />
-    </Wearable>
-    <Holdable slots="RightHand+LeftHand" holdpos="0,-70" handle1="0,0-30" handle2="0,-30" holdangle="0" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" pickkey="Use" allowswappingwhenpicked="false" />
-    <ItemContainer capacity="2" maxstacksize="12">
-      <Containable items="smallitem" excludeditems="packable,medpackable" />
-      <SlotIcon slotindex="3" texture="%ModDir%/UI/Sloticons.png" sourcerect="0,0,64,64" origin="0.5,0.5" />
-      <SlotIcon slotindex="2" texture="%ModDir%/UI/Sloticons.png" sourcerect="0,0,64,64" origin="0.5,0.5" />
-      <SubContainer capacity="2" maxstacksize="1">
-        <Containable items="packable,smallitem" excludeditems="medpackable" />
-      </SubContainer>
-    </ItemContainer>
-  </Item>
-  <Item name="" identifier="WR_coalitionmedgear" category="Equipment" tags="mediumitem,clothing" scale="0.5" cargocontaineridentifier="metalcrate" allowasextracargo="true" description="" impactsoundtag="impact_soft">
-    <InventoryIcon texture="%ModDir%/Sprites/Items/Inventory Icons.png" sourcerect="320,0,64,64" origin="0.5,0.5" />
-    <Sprite texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" sourcerect="443,70,58,89" depth="0.6" origin="0.5,0.35" />
-    <Body radius="30" height="30" density="15" />
-    <Wearable slots="OuterClothes" msg="ItemMsgPickUpSelect" canbeselected="false" canbepicked="true" pickkey="Select">
-      <sprite name="Coalition Med Rig Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" limb="Torso" hidelimb="false" sourcerect="443,70,58,89" inherittexturescale="true" origin="0.55,0.64" />
-      <SkillModifier skillidentifier="medical" skillvalue="30" />
-      <StatValue stattype="BuffItemApplyingMultiplier" value="0.5" />
-      <StatValue stattype="MedicalItemApplyingMultiplier" value="0.5" />
-    </Wearable>
-    <Holdable slots="RightHand+LeftHand" holdpos="0,-70" handle1="0,0-30" handle2="0,-30" holdangle="0" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" pickkey="Use" allowswappingwhenpicked="false" />
-    <ItemContainer capacity="2" maxstacksize="12">
-      <Containable items="medical,chem" excludeditems="medpackable" />
-      <SlotIcon slotindex="3" texture="%ModDir%/UI/Sloticons.png" sourcerect="64,0,64,64" origin="0.5,0.5" />
-      <SlotIcon slotindex="2" texture="%ModDir%/UI/Sloticons.png" sourcerect="64,0,64,64" origin="0.5,0.5" />
-      <SubContainer capacity="2" maxstacksize="1">
-        <Containable items="medpackable,medical,chem" excludeditems="packable" />
-      </SubContainer>
-    </ItemContainer>
-  </Item>
-  <!-- Infantry gear End -->
-  <!-- Uniform Start -->
-  <Item name="" identifier="WR_coalitionuniform" category="Equipment" tags="smallitem,clothing" fireproof="false" cargocontaineridentifier="metalcrate" description="" scale="0.5" impactsoundtag="impact_soft">
-    <InventoryIcon name="Coalition Uniform Icon" texture="%ModDir%/Sprites/Items/Inventory Icons.png" sourcerect="64,64,64,64" origin="0.5,0.5" />
-    <Sprite name="Coalition Uniform" texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" sourcerect="0,198,116,58" depth="0.6" origin="0.5,0.5" />
-    <Body width="100" height="50" density="15" friction="0.8" restitution="0.01" />
-    <Wearable slots="Any,InnerClothes" msg="ItemMsgPickUpSelect">
-      <sprite name="Coalition Uniform Torso" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="Torso" hidelimb="false" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Left Lower Arm" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Right Lower Arm" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Left Upper Arm" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Right Upper Arm" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Waist" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="Waist" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Right Thigh" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Left Thigh" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Right Leg" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Left Leg" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Right Shoe" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <sprite name="Coalition Uniform Left Shoe" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
-      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="lacerations" damagemultiplier="0.95" />
-      <damagemodifier armorsector="0.0,360.0" afflictionidentifiers="gunshotwound, bitewounds" damagemultiplier="0.9" />
-    </Wearable>
-  </Item>
-  <!-- Uniform End -->
+	<!-- Helmets Start -->
+	<Item name="" identifier="WR_coalitionhelmet" category="Equipment" tags="smallitem,clothing" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_metal_heavy" scale="0.325">
+		<Sprite name="Coalition Helmet" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" sourcerect="607,0,89,67" depth="0.6" origin="0.5,0.5" />
+		<Body radius="30" density="25" />
+		<Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
+			<damagemodifier afflictionidentifiers="gunshotwound" armorsector="0.0,360.0" damagemultiplier="0.8" damagesound="LimbArmor" deflectprojectiles="true" />
+			<damagemodifier afflictionidentifiers="lacerations, blunttrauma, explosiondamage, bleeding" armorsector="0.0,360.0" damagemultiplier="0.6" damagesound="LimbArmor" deflectprojectiles="true" />
+			<damagemodifier afflictionidentifiers="concussion" armorsector="0.0,360.0" damagemultiplier="0.1" damagesound="" deflectprojectiles="true" />
+			<SkillModifier skillidentifier="weapons" skillvalue="10" />
+			<sprite name="Coalition Helmet Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.65" hidewearablesoftype="Hair" sourcerect="607,0,89,102" origin="0.535,0.65" />
+		</Wearable>
+	</Item>
+	<Item name="" identifier="WR_coalitionmedhelmet" category="Equipment" tags="smallitem,clothing" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_metal_heavy" scale="0.325">
+		<Sprite name="Coalition Medic Helmet" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" sourcerect="607,102,89,43" depth="0.6" origin="0.5,0.5" />
+		<Body radius="30" density="25" />
+		<Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
+			<damagemodifier afflictionidentifiers="gunshotwound, bitewounds" armorsector="0.0,360.0" damagemultiplier="0.8" damagesound="LimbArmor" deflectprojectiles="true" />
+			<damagemodifier afflictionidentifiers="lacerations, blunttrauma, explosiondamage, bleeding" armorsector="0.0,360.0" damagemultiplier="0.6" damagesound="LimbArmor" deflectprojectiles="true" />
+			<damagemodifier afflictionidentifiers="concussion" armorsector="0.0,360.0" damagemultiplier="0.1" damagesound="" deflectprojectiles="true" />
+			<SkillModifier skillidentifier="medical" skillvalue="10" />
+			<sprite name="Coalition Medic Helmet Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.65" hidewearablesoftype="Hair" sourcerect="607,102,89,79" origin="0.535,0.54" />
+		</Wearable>
+	</Item>
+	<Item name="" identifier="WR_coalitioncomhat" category="Equipment" tags="smallitem,clothing,command" cargocontaineridentifier="metalcrate" description="" impactsoundtag="impact_soft" scale="0.25">
+		<Sprite name="Coalition Commander Hat" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" sourcerect="385,58,120,47" depth="0.6" origin="0.5,0.14" />
+		<Body radius="30" density="25" />
+		<Wearable slots="Any,Head" armorvalue="20.0" msg="ItemMsgPickUpSelect">
+			<damagemodifier afflictionidentifiers="lacerations, blunttrauma, explosiondamage, bleeding" armorsector="0.0,360.0" damagemultiplier="0.8" damagesound="LimbArmor" deflectprojectiles="true" />
+			<SkillModifier skillidentifier="weapons" skillvalue="10" />
+			<sprite name="Coalition Commander Hat Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Headgear.png" limb="Head" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.5" sourcerect="385,58,120,47" origin="0.525,1.2" />
+		</Wearable>
+	</Item>
+	<!-- Helmets End -->
+	<!-- Infantry gear Start -->
+	<Item name="" identifier="WR_coalitiongear" category="Equipment" tags="mediumitem,clothing" scale="0.5" cargocontaineridentifier="metalcrate" allowasextracargo="true" description="" impactsoundtag="impact_soft">
+		<InventoryIcon texture="%ModDir%/Sprites/Items/Inventory Icons.png" sourcerect="256,0,64,64" origin="0.5,0.5" />
+		<Sprite texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" sourcerect="443,162,69,94" depth="0.6" origin="0.5,0.35" />
+		<Body radius="30" height="30" density="15" />
+		<Wearable slots="OuterClothes" msg="ItemMsgPickUpSelect" canbeselected="false" canbepicked="true" pickkey="Select">
+			<sprite name="Coalition Chest Rig Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" limb="Torso" hidelimb="false" sourcerect="443,162,69,94" inherittexturescale="true" origin="0.45,0.65" />
+			<SkillModifier skillidentifier="weapons" skillvalue="30" />
+		</Wearable>
+		<Holdable slots="RightHand+LeftHand" holdpos="0,-70" handle1="0,0-30" handle2="0,-30" holdangle="0" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" pickkey="Use" allowswappingwhenpicked="false" />
+		<ItemContainer capacity="2" maxstacksize="12">
+			<Containable items="smallitem" excludeditems="packable,medpackable" />
+			<SlotIcon slotindex="3" texture="%ModDir%/UI/Sloticons.png" sourcerect="0,0,64,64" origin="0.5,0.5" />
+			<SlotIcon slotindex="2" texture="%ModDir%/UI/Sloticons.png" sourcerect="0,0,64,64" origin="0.5,0.5" />
+			<SubContainer capacity="2" maxstacksize="1">
+				<Containable items="packable,smallitem" excludeditems="medpackable" />
+			</SubContainer>
+		</ItemContainer>
+	</Item>
+	<Item name="" identifier="WR_coalitionmedgear" category="Equipment" tags="mediumitem,clothing" scale="0.5" cargocontaineridentifier="metalcrate" allowasextracargo="true" description="" impactsoundtag="impact_soft">
+		<InventoryIcon texture="%ModDir%/Sprites/Items/Inventory Icons.png" sourcerect="320,0,64,64" origin="0.5,0.5" />
+		<Sprite texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" sourcerect="443,70,58,89" depth="0.6" origin="0.5,0.35" />
+		<Body radius="30" height="30" density="15" />
+		<Wearable slots="OuterClothes" msg="ItemMsgPickUpSelect" canbeselected="false" canbepicked="true" pickkey="Select">
+			<sprite name="Coalition Med Rig Wearable" texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" limb="Torso" hidelimb="false" sourcerect="443,70,58,89" inherittexturescale="true" origin="0.55,0.64" />
+			<SkillModifier skillidentifier="medical" skillvalue="30" />
+			<StatValue stattype="BuffItemApplyingMultiplier" value="0.5" />
+			<StatValue stattype="MedicalItemApplyingMultiplier" value="0.5" />
+		</Wearable>
+		<Holdable slots="RightHand+LeftHand" holdpos="0,-70" handle1="0,0-30" handle2="0,-30" holdangle="0" msg="ItemMsgPickUpUse" canbeselected="false" canbepicked="true" pickkey="Use" allowswappingwhenpicked="false" />
+		<ItemContainer capacity="2" maxstacksize="12">
+			<Containable items="medical,chem" excludeditems="medpackable" />
+			<SlotIcon slotindex="3" texture="%ModDir%/UI/Sloticons.png" sourcerect="64,0,64,64" origin="0.5,0.5" />
+			<SlotIcon slotindex="2" texture="%ModDir%/UI/Sloticons.png" sourcerect="64,0,64,64" origin="0.5,0.5" />
+			<SubContainer capacity="2" maxstacksize="1">
+				<Containable items="medpackable,medical,chem" excludeditems="packable" />
+			</SubContainer>
+		</ItemContainer>
+	</Item>
+	<!-- Infantry gear End -->
+	<!-- Uniform Start -->
+	<Item name="" identifier="WR_coalitionuniform" category="Equipment" tags="smallitem,clothing" fireproof="false" cargocontaineridentifier="metalcrate" description="" scale="0.5" impactsoundtag="impact_soft">
+		<InventoryIcon name="Coalition Uniform Icon" texture="%ModDir%/Sprites/Items/Inventory Icons.png" sourcerect="64,64,64,64" origin="0.5,0.5" />
+		<Sprite name="Coalition Uniform" texture="%ModDir%/Sprites/Items/Jobgear/Coalitiongear.png" sourcerect="0,198,116,58" depth="0.6" origin="0.5,0.5" />
+		<Body width="100" height="50" density="15" friction="0.8" restitution="0.01" />
+	<ItemComponent characterusable="false">
+		<StatusEffect type="OnNotContained" target="This" delay="0.01">
+				<Remove />
+		</StatusEffect>
+		<StatusEffect type="OnWearing" target="Character" TeamId="Team2" setvalue="true" noninteractable="True"/>
+    <StatusEffect type="OnSpawn" target="This" noninteractable="True"/>
+	</ItemComponent>
+		<Wearable slots="Any,InnerClothes" msg="ItemMsgPickUpSelect">
+			<sprite name="Coalition Uniform Torso" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="Torso" hidelimb="false" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Left Lower Arm" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Right Lower Arm" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightForearm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Left Upper Arm" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Right Upper Arm" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightArm" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Waist" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="Waist" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Right Thigh" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Left Thigh" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftThigh" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Right Leg" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Left Leg" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftLeg" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Right Shoe" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="RightFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<sprite name="Coalition Uniform Left Shoe" texture="%ModDir%/Sprites/Items/Jobgear/CoalitionUniform.png" limb="LeftFoot" hidelimb="true" inherittexturescale="true" inheritorigin="true" inheritsourcerect="true" />
+			<damagemodifier armorsector="0.0,360.0" afflictionidentifiers="lacerations" damagemultiplier="0.95" />
+			<damagemodifier armorsector="0.0,360.0" afflictionidentifiers="gunshotwound, bitewounds" damagemultiplier="0.9" />
+		</Wearable>
+	</Item>
+	<!-- Uniform End -->
 </Items>


### PR DESCRIPTION
Makes the Coalition be forced onto Team B
This would mean Renegades be automatically be set at A team This has the bonus of each team having their own radio station and their names appear red to the other team
![20240323192143_1](https://github.com/SONKSquall/WarfaremodGeneralContent/assets/33539475/9434313d-6c9c-4612-8b55-a6b92396a637)
